### PR TITLE
Ignore html-files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-language=Kotlin


### PR DESCRIPTION
I think it would be better to ignore html-files because it looks a bit confusing for people who are looking for that stuff (Android or Kotlin library, unidirectional architecture implementation, etc).